### PR TITLE
Adding unit test for ante

### DIFF
--- a/app/decorators/ante_test.go
+++ b/app/decorators/ante_test.go
@@ -1,0 +1,126 @@
+package decorators_test
+
+import (
+	"testing"
+
+	"github.com/CudoVentures/cudos-node/app"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	simappparams "github.com/cosmos/cosmos-sdk/simapp/params"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	xauthsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/suite"
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	dbm "github.com/tendermint/tm-db"
+)
+
+type AnteTestSuite struct {
+	suite.Suite
+
+	app         *app.App
+	anteHandler sdk.AnteHandler
+	ctx         sdk.Context
+	clientCtx   client.Context
+	txBuilder   client.TxBuilder
+}
+
+// returns context and app with params set on account keeper
+func createTestApp(isCheckTx bool, tempDir string) (*app.App, sdk.Context) {
+	db := dbm.NewMemDB()
+	encCdc := app.MakeEncodingConfig()
+
+	cudosApp := app.New(
+		log.NewNopLogger(),
+		db,
+		nil,
+		true,
+		map[int64]bool{},
+		tempDir,
+		5,
+		encCdc,
+		simapp.EmptyAppOptions{},
+	)
+	ctx := cudosApp.BaseApp.NewContext(isCheckTx, tmproto.Header{})
+	cudosApp.AccountKeeper.SetParams(ctx, authtypes.DefaultParams())
+
+	return cudosApp, ctx
+}
+
+// SetupTest setups a new test, with new app, context, and anteHandler.
+func (suite *AnteTestSuite) SetupTest(isCheckTx bool) {
+	tempDir := suite.T().TempDir()
+	suite.app, suite.ctx = createTestApp(isCheckTx, tempDir)
+	suite.ctx = suite.ctx.WithBlockHeight(1)
+
+	// Set up TxConfig.
+	encodingConfig := suite.SetupEncoding()
+
+	suite.clientCtx = client.Context{}.
+		WithTxConfig(encodingConfig.TxConfig)
+}
+
+func (suite *AnteTestSuite) SetupEncoding() simappparams.EncodingConfig {
+	encodingConfig := simapp.MakeTestEncodingConfig()
+	// We're using TestMsg encoding in some tests, so register it here.
+	encodingConfig.Amino.RegisterConcrete(&testdata.TestMsg{}, "testdata.TestMsg", nil)
+	testdata.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
+	return encodingConfig
+}
+
+func TestAnteTestSuite(t *testing.T) {
+	suite.Run(t, new(AnteTestSuite))
+}
+
+// CreateTestTx is a helper function to create a tx given multiple inputs.
+func (suite *AnteTestSuite) CreateTestTx(privs []cryptotypes.PrivKey, accNums []uint64, accSeqs []uint64, chainID string) (xauthsigning.Tx, error) {
+	// First round: we gather all the signer infos. We use the "set empty
+	// signature" hack to do that.
+	var sigsV2 []signing.SignatureV2
+	for i, priv := range privs {
+		sigV2 := signing.SignatureV2{
+			PubKey: priv.PubKey(),
+			Data: &signing.SingleSignatureData{
+				SignMode:  suite.clientCtx.TxConfig.SignModeHandler().DefaultMode(),
+				Signature: nil,
+			},
+			Sequence: accSeqs[i],
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+	err := suite.txBuilder.SetSignatures(sigsV2...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Second round: all signer infos are set, so each signer can sign.
+	sigsV2 = []signing.SignatureV2{}
+	for i, priv := range privs {
+		signerData := xauthsigning.SignerData{
+			ChainID:       chainID,
+			AccountNumber: accNums[i],
+			Sequence:      accSeqs[i],
+		}
+		sigV2, err := tx.SignWithPrivKey(
+			suite.clientCtx.TxConfig.SignModeHandler().DefaultMode(), signerData,
+			suite.txBuilder, priv, suite.clientCtx.TxConfig, accSeqs[i])
+		if err != nil {
+			return nil, err
+		}
+
+		sigsV2 = append(sigsV2, sigV2)
+	}
+	err = suite.txBuilder.SetSignatures(sigsV2...)
+	if err != nil {
+		return nil, err
+	}
+
+	return suite.txBuilder.GetTx(), nil
+}

--- a/app/decorators/crisis_onlyadmin_test.go
+++ b/app/decorators/crisis_onlyadmin_test.go
@@ -1,0 +1,61 @@
+package decorators_test
+
+import (
+	"github.com/CudoVentures/cudos-node/app/decorators"
+	cudoMinttypes "github.com/CudoVentures/cudos-node/x/cudoMint/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+)
+
+// TestCrisisOnlyAdmin tests that the decorator properly checks for admin tokens
+func (suite *AnteTestSuite) TestCrisisOnlyAdmin() {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	adminAmount := sdk.NewCoins(sdk.NewCoin("cudosAdmin", sdk.NewInt(100000000000000)))
+
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	priv2, _, addr2 := testdata.KeyTestPubAddr()
+	suite.Require().NoError(suite.app.BankKeeper.MintCoins(suite.ctx, cudoMinttypes.ModuleName, adminAmount))
+
+	suite.Require().NoError(
+		suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, cudoMinttypes.ModuleName, addr1, adminAmount),
+	)
+	decorator := decorators.NewOnlyAdminVerifyInvariantDecorator(suite.app.BankKeeper)
+	antehandler := sdk.ChainAnteDecorators(decorator)
+
+	// Set IsCheckTx to true
+	suite.ctx = suite.ctx.WithIsCheckTx(true)
+
+	// normal so ok
+	suite.ctx = suite.ctx.WithBlockHeight(100)
+	suite.Require().NoError(suite.txBuilder.SetMsgs(
+		&crisistypes.MsgVerifyInvariant{
+			Sender:              addr1.String(),
+			InvariantModuleName: cudoMinttypes.ModuleName,
+			InvariantRoute:      cudoMinttypes.RouterKey,
+		},
+	))
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1, priv2}, []uint64{0, 1}, []uint64{0, 0}
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().NoError(err)
+
+	// not admin
+	suite.Require().NoError(suite.txBuilder.SetMsgs(
+		&crisistypes.MsgVerifyInvariant{
+			Sender:              addr2.String(),
+			InvariantModuleName: cudoMinttypes.ModuleName,
+			InvariantRoute:      cudoMinttypes.RouterKey,
+		},
+	))
+	tx, err = suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().Equal(err, decorators.ErrAdminOnly)
+}

--- a/app/decorators/staking_mindelegation_test.go
+++ b/app/decorators/staking_mindelegation_test.go
@@ -1,0 +1,72 @@
+package decorators_test
+
+import (
+	"github.com/CudoVentures/cudos-node/app/decorators"
+	cudoMinttypes "github.com/CudoVentures/cudos-node/x/cudoMint/types"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/testdata"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func (suite *AnteTestSuite) TestStakingMin() {
+	suite.SetupTest(true) // setup
+	suite.txBuilder = suite.clientCtx.TxConfig.NewTxBuilder()
+
+	adminAmount := sdk.NewCoins(sdk.NewCoin("cudosAdmin", sdk.NewInt(100000000000000)))
+
+	priv1, _, addr1 := testdata.KeyTestPubAddr()
+	priv2, _, addr2 := testdata.KeyTestPubAddr()
+	suite.Require().NoError(suite.app.BankKeeper.MintCoins(suite.ctx, cudoMinttypes.ModuleName, adminAmount))
+
+	suite.Require().NoError(
+		suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, cudoMinttypes.ModuleName, addr1, adminAmount),
+	)
+	decorator := decorators.NewMinSelfDelegationDecorator()
+	antehandler := sdk.ChainAnteDecorators(decorator)
+
+	// Set IsCheckTx to true
+	suite.ctx = suite.ctx.WithIsCheckTx(true)
+
+	// normal so ok
+	suite.ctx = suite.ctx.WithBlockHeight(100)
+	minSelfDelegator, _ := sdk.NewIntFromString(decorators.MinSelfDelegation)
+	suite.Require().NoError(suite.txBuilder.SetMsgs(
+		&stakingtypes.MsgCreateValidator{
+			Description:       stakingtypes.Description{},
+			Commission:        stakingtypes.CommissionRates{},
+			MinSelfDelegation: minSelfDelegator,
+			DelegatorAddress:  string(addr1),
+			ValidatorAddress:  string(addr2),
+			Pubkey:            nil,
+			Value:             sdk.Coin{},
+		},
+	))
+
+	privs, accNums, accSeqs := []cryptotypes.PrivKey{priv1, priv2}, []uint64{0, 1}, []uint64{0, 0}
+	tx, err := suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().NoError(err)
+
+	// Not enough self delegation
+	suite.ctx = suite.ctx.WithBlockHeight(100)
+	suite.Require().NoError(suite.txBuilder.SetMsgs(
+		&stakingtypes.MsgCreateValidator{
+			Description:       stakingtypes.Description{},
+			Commission:        stakingtypes.CommissionRates{},
+			MinSelfDelegation: sdk.NewInt(1),
+			DelegatorAddress:  string(addr1),
+			ValidatorAddress:  string(addr2),
+			Pubkey:            nil,
+			Value:             sdk.Coin{},
+		},
+	))
+
+	tx, err = suite.CreateTestTx(privs, accNums, accSeqs, suite.ctx.ChainID())
+	suite.Require().NoError(err)
+
+	_, err = antehandler(suite.ctx, tx, false)
+	suite.Require().Error(err)
+}


### PR DESCRIPTION
Implement task #112, supporting unit tests for two ante:
- crisis_onlyadmin
- staking_mindelegation

